### PR TITLE
Add Google Pay integration placeholder

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,24 @@ This TODO list is derived from the project's `README.md` and aims to guide devel
     - **Sub-Task:** [x] Implement a function in GAS to log new orders to a Google Sheet. (Completed in `backend/google_apps_script_backend.gs.js`).
     - **Sub-Task:** [x] Document how to set up and deploy this GAS backend. (Documentation created in `docs/google_apps_script_setup.md`).
     - **Rationale:** This is the first unchecked major item in the `README.md` roadmap (v1.1) and adds significant value through data persistence and automation.
+- [ ] **Task:** Build Administrative Dashboard.
+    - **Details:** Use Google Apps Script or Google Data Studio to visualize orders and key metrics from the spreadsheet.
+    - **Rationale:** Gives restaurant owners real-time insights into sales.
+- [ ] **Task:** Implement Automated Email Notifications.
+    - **Details:** Configure GAS to send order confirmations or periodic summaries via email.
+    - **Rationale:** Streamlines communication with customers and staff.
+- [ ] **Task:** Generate Sales Reports.
+    - **Details:** Add GAS functions to compile daily or weekly sales reports from logged orders.
+    - **Rationale:** Facilitates performance tracking and inventory planning.
+- [ ] **Task:** Provide Webhook Endpoints for Integrations.
+    - **Details:** Expose simple GAS webhooks so external systems can receive new order data.
+    - **Rationale:** Enables integration with other services and automation tools.
+- [ ] **Task:** Research Open Source Store Frameworks.
+    - **Details:** Evaluate solutions like WooCommerce, Magento Open Source, PrestaShop, OpenCart e Odoo.
+    - **Rationale:** Identificar recursos que possamos reutilizar ou integrar mantendo o espírito open source.
+- [ ] **Task:** Integrar Pagamento via Google Pay.
+    - **Details:** Adicionar botão Google Pay no front-end utilizando a API `google.payments.api`.
+    - **Rationale:** Oferecer uma alternativa de pagamento digital amplamente usada.
 - [~] **Task:** Refine `menu.csv` and `menu.json` examples and documentation.
     - **Sub-Task:** [x] Main `README.md`'s `menu.csv` example refined and linked to detailed guide in `docs/README.md#configuration`.
     - **Sub-Task:** [x] Provide a sample `menu.json` file in the repository (e.g., `menu_example.json`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,7 @@ Each menu item object in the array should have the following fields:
 - Digital Menu Display
 - Shopping Cart & Ordering
 - PIX Payment (Client-Side QR Generation)
+- Google Pay Button (experimental) - veja [Google Pay Setup](google_pay_setup.md)
 - WhatsApp Integration
 - Order History ("Smart History")
 - Progressive Web App (PWA) Functionality
@@ -141,6 +142,10 @@ We welcome contributions! Please see the main project `README.md` for initial gu
 - Reporting Bugs
 - Suggesting Enhancements
 - Code Contribution Guidelines
+## Open Source Store Frameworks
+Para sugestões de plataformas completas de e-commerce que podem ser integradas ao Tembiu, confira o documento [Store Frameworks](store_frameworks.md).
+Para habilitar pagamentos com Google Pay, consulte o guia [Google Pay Setup](google_pay_setup.md).
+
 
 ## Troubleshooting
 

--- a/docs/google_pay_setup.md
+++ b/docs/google_pay_setup.md
@@ -1,0 +1,37 @@
+# Google Pay Integration Guide
+
+This guide provides a basic overview of how to enable the Google Pay button in Tembiu.
+
+## 1. Enable Google Pay API
+
+1. Access the [Google Pay API documentation](https://developers.google.com/pay/api/web/guides/tutorial).
+2. Create or use an existing Google Pay merchant account.
+3. Obtain your `merchantId` and configure a payment gateway (for example, Stripe or another supported provider).
+
+## 2. Configure `js/google_pay.js`
+
+The file `js/google_pay.js` contains a minimal example using the `google.payments.api` library in **TEST** mode. Replace the placeholder `gateway` and `gatewayMerchantId` with your payment gateway details and update the `merchantId` and `merchantName` fields:
+
+```javascript
+const paymentDataRequest = {
+  // ...
+  tokenizationSpecification: {
+    type: 'PAYMENT_GATEWAY',
+    parameters: {
+      gateway: 'YOUR_GATEWAY',
+      gatewayMerchantId: 'YOUR_ID'
+    }
+  },
+  merchantInfo: {
+    merchantId: 'YOUR_MERCHANT_ID',
+    merchantName: 'YOUR_RESTAURANT'
+  }
+};
+```
+
+## 3. Testing
+
+With the placeholders filled, load the app locally and the Google Pay button will appear after checkout. When pressed, the API will prompt a test payment and log the result in the browser console.
+
+This example is intended as a starting point and does not handle real payment confirmation. For production use, consult the official Google Pay documentation and implement secure backend processing.
+

--- a/docs/store_frameworks.md
+++ b/docs/store_frameworks.md
@@ -1,0 +1,24 @@
+# Open Source Store Frameworks
+
+Este documento resume algumas plataformas de e-commerce de código aberto que podem servir de inspiração ou integração para o Tembiu.
+
+## Por que avaliar frameworks existentes?
+- Aproveitar recursos já consolidados e economizar desenvolvimento.
+- Contar com comunidades ativas e grande variedade de plugins/extensões.
+- Facilitar integrações com meios de pagamento e logística.
+
+## Opções populares
+
+| Framework | Licença | Destaques |
+|-----------|---------|-----------|
+| **WooCommerce** | GPLv3 | Plugin do WordPress, ecossistema enorme, fácil de personalizar. |
+| **Magento Open Source** | OSL 3.0 | Escalável, robusto, muitas funcionalidades nativas. |
+| **PrestaShop** | OSL 3.0 | Focado em e-commerce, interface de administração intuitiva. |
+| **OpenCart** | GPLv3 | Leve, instalação simples, muitas extensões grátis. |
+| **Odoo eCommerce** | LGPL | Parte do ERP Odoo, integração com CRM e estoque. |
+
+## Mantendo o espírito open source
+- Todas as soluções acima permitem uso e modificação livres.
+- Verifique compatibilidade de licenças antes de incorporar código.
+- Integrações via API ou estudo de ideias não alteram a licença MIT do Tembiu.
+

--- a/index.html
+++ b/index.html
@@ -35,7 +35,12 @@
             <div id="pix-qr-code">[Placeholder para QR Code PIX]</div>
             <p><strong>Copia e Cola:</strong> <code id="pix-copy-paste-code">[Placeholder para Código PIX Copia e Cola]</code></p>
             <button id="confirm-payment-button">Confirmar Pagamento (Simulado)</button>
-            <button id="whatsapp-share-button" style="margin-top: 10px;">Compartilhar Pedido no WhatsApp</button> 
+            <button id="whatsapp-share-button" style="margin-top: 10px;">Compartilhar Pedido no WhatsApp</button>
+        </section>
+
+        <section id="google-pay-container" style="display:none;">
+            <h2>Pagar com Google Pay</h2>
+            <div id="google-pay-button"></div>
         </section>
 
         <section id="order-history-container">
@@ -52,6 +57,8 @@
     </footer>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+    <script async src="https://pay.google.com/gp/p/js/pay.js" onload="onGooglePayLoaded()"></script>
     <script src="js/main.js"></script>
+    <script src="js/google_pay.js"></script>
 </body>
 </html>

--- a/js/google_pay.js
+++ b/js/google_pay.js
@@ -1,0 +1,57 @@
+// Minimal Google Pay integration for Tembiu
+// This implementation runs in TEST environment and only logs the payment data.
+
+let googlePayClient;
+
+function onGooglePayLoaded() {
+    if (!window.google || !google.payments) {
+        console.warn('Google Pay library not available.');
+        return;
+    }
+    googlePayClient = new google.payments.api.PaymentsClient({ environment: 'TEST' });
+    const button = googlePayClient.createButton({ onClick: onGooglePayButtonClicked });
+    const container = document.getElementById('google-pay-button');
+    if (container) {
+        container.appendChild(button);
+    }
+}
+
+function onGooglePayButtonClicked() {
+    if (!googlePayClient) return;
+    const paymentDataRequest = {
+        apiVersion: 2,
+        apiVersionMinor: 0,
+        allowedPaymentMethods: [{
+            type: 'CARD',
+            parameters: {
+                allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                allowedCardNetworks: ['VISA', 'MASTERCARD']
+            },
+            tokenizationSpecification: {
+                type: 'PAYMENT_GATEWAY',
+                parameters: {
+                    gateway: 'example', // replace with real gateway
+                    gatewayMerchantId: 'exampleGatewayMerchantId'
+                }
+            }
+        }],
+        merchantInfo: {
+            merchantId: 'B0123456789012345678', // placeholder merchant ID
+            merchantName: 'Tembiu Demo'
+        },
+        transactionInfo: {
+            totalPriceStatus: 'FINAL',
+            totalPrice: '1.00', // placeholder price
+            currencyCode: 'BRL'
+        }
+    };
+
+    googlePayClient.loadPaymentData(paymentDataRequest)
+        .then(paymentData => {
+            console.log('Received Google Pay payment data:', paymentData);
+            alert('Google Pay payment autorizado (simulado).');
+        })
+        .catch(err => {
+            console.error('Google Pay payment failed:', err);
+        });
+}


### PR DESCRIPTION
## Summary
- expand roadmap with Google Pay task
- add docs describing Google Pay setup and reference it in docs README
- insert Google Pay button container and scripts in index.html
- provide minimal `js/google_pay.js` implementation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683fc04e9308832584679465cf51bcbe