### PR TITLE
Add Clear History button

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -110,7 +110,7 @@ This TODO list is derived from the project's `README.md` and aims to guide devel
     - **Sub-Task:** Add a UI toggle (e.g., in the header or footer).
     - **Sub-Task:** Implement JS to switch themes and save user preference in localStorage.
     - **Rationale:** UI/UX enhancement listed in README.
-- [ ] **Task:** Implement "Clear Order History" Button (v1.x).
+- [x] **Task:** Implement "Clear Order History" Button (v1.x).
     - **Sub-Task:** Add a "Clear History" button to the order history section in `index.html`.
     - **Sub-Task:** Implement `handleClearHistory()` function in `js/main.js` to remove `tembiuOrderHistory` from localStorage and update the UI.
     - **Sub-Task:** Add a confirmation prompt before clearing.

--- a/docs/README.md
+++ b/docs/README.md
@@ -195,6 +195,7 @@ Tembiu is packed with features designed to provide a seamless experience for bot
 *   **Order History ("Smart History"):**
     *   Saves past orders to the user's local browser storage.
     *   "Order Again" functionality allows quick re-ordering of items from past orders.
+    *   A "Clear History" button lets users delete saved orders at any time, honoring the "Right to be forgotten" principle.
 
 *   **Progressive Web App (PWA) Functionality:**
     *   Installable on user devices for an app-like experience (icon on home screen).

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
 
         <section id="order-history-container">
             <h2>Seus Últimos Pedidos</h2>
+            <button id="clear-history-button">Limpar Histórico</button>
             <div id="past-orders-list">
                 <p>Nenhum pedido encontrado no seu histórico.</p>
             </div>

--- a/js/main.js
+++ b/js/main.js
@@ -65,6 +65,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (saveAddressButton) {
         saveAddressButton.addEventListener('click', handleSaveAddress);
     }
+
+    const clearHistoryButton = document.getElementById('clear-history-button');
+    if (clearHistoryButton) {
+        clearHistoryButton.addEventListener('click', handleClearHistory);
+    }
 });
 
 async function loadMenu() {
@@ -457,7 +462,7 @@ function loadOrderHistory() {
     });
 }
 
-function handleOrderAgain(orderItemsFromHistory) { 
+function handleOrderAgain(orderItemsFromHistory) {
     console.log("Order Again clicked. Items to re-populate:", orderItemsFromHistory);
     cart = []; 
 
@@ -476,6 +481,15 @@ function handleOrderAgain(orderItemsFromHistory) {
     if (cartContainer) {
         cartContainer.scrollIntoView({ behavior: 'smooth' });
     }
+}
+
+function handleClearHistory() {
+    const confirmation = confirm("Tem certeza que deseja limpar seu histórico de pedidos?");
+    if (!confirmation) return;
+
+    localStorage.removeItem('tembiuOrderHistory');
+    loadOrderHistory();
+    alert("Histórico de pedidos limpo com sucesso.");
 }
 
 function formatCartForWhatsApp(cartArray) {


### PR DESCRIPTION
## Summary
- add "Clear History" button in the order history section
- implement `handleClearHistory` handler to remove localStorage order history after user confirmation
- document new feature in docs
- mark task done in TODO list

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841fa0221988325b338813b292b3fc7