### PR TITLE
Add client-side analytics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ Toast: "💡 Que tal uma Coca-Cola? +1"
   "clientesFrequentes": ["11999999999", "11888888888"]
 }
 ```
+- 📊 **Estatísticas na página** - seção "Estatísticas" exibe o total de pedidos,
+  ticket médio e itens mais populares.
 
 ### **Relatórios Automáticos** (com GAS)
 - 📈 **Vendas por período**

--- a/TODO.md
+++ b/TODO.md
@@ -115,7 +115,7 @@ This TODO list is derived from the project's `README.md` and aims to guide devel
     - **Sub-Task:** Implement `handleClearHistory()` function in `js/main.js` to remove `tembiuOrderHistory` from localStorage and update the UI.
     - **Sub-Task:** Add a confirmation prompt before clearing.
     - **Rationale:** Fulfills "Direito ao esquecimento" mentioned in README.
-- [ ] **Task:** Display Basic Client-Side Analytics (v1.x).
+- [x] **Task:** Display Basic Client-Side Analytics (v1.x).
     - **Sub-Task:** Create a new section/modal in `index.html` for analytics.
     - **Sub-Task:** In `js/main.js`, add functions to calculate and display simple metrics from `localStorage` order history:
         - Total number of orders made.

--- a/index.html
+++ b/index.html
@@ -88,6 +88,12 @@
                 <p>Nenhum pedido encontrado no seu histórico.</p>
             </div>
         </section>
+        <section id="analytics-container">
+            <h2>Estatísticas</h2>
+            <div id="analytics-content">
+                <p>Nenhum dado disponível.</p>
+            </div>
+        </section>
     </main>
 
     <footer>

--- a/js/main.js
+++ b/js/main.js
@@ -455,7 +455,7 @@ function loadOrderHistory() {
         return;
     }
 
-    pastOrdersList.innerHTML = ''; 
+    pastOrdersList.innerHTML = '';
     history.forEach(order => { // order.items here have quantity
         const orderDiv = document.createElement('div');
         orderDiv.classList.add('past-order');
@@ -487,6 +487,8 @@ function loadOrderHistory() {
         
         pastOrdersList.appendChild(orderDiv);
     });
+
+    updateAnalytics(history);
 }
 
 function handleOrderAgain(orderItemsFromHistory) {
@@ -517,6 +519,41 @@ function handleClearHistory() {
     localStorage.removeItem('tembiuOrderHistory');
     loadOrderHistory();
     alert("Histórico de pedidos limpo com sucesso.");
+}
+
+function calculateAnalytics(history) {
+    const totals = { totalOrders: history.length, totalValue: 0, items: {} };
+    history.forEach(order => {
+        order.items.forEach(item => {
+            const qty = item.quantity || 1;
+            totals.totalValue += item.preco * qty;
+            totals.items[item.nome] = (totals.items[item.nome] || 0) + qty;
+        });
+    });
+    const averageOrderValue = totals.totalOrders ? totals.totalValue / totals.totalOrders : 0;
+    const topItems = Object.entries(totals.items)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([name, count]) => ({ name, count }));
+    return { totalOrders: totals.totalOrders, averageOrderValue, topItems };
+}
+
+function updateAnalytics(history) {
+    const container = document.getElementById('analytics-content');
+    if (!container) return;
+    const { totalOrders, averageOrderValue, topItems } = calculateAnalytics(history);
+    let html = `<p>Total de Pedidos: ${totalOrders}</p>`;
+    html += `<p>Valor Médio dos Pedidos: R$ ${averageOrderValue.toFixed(2)}</p>`;
+    if (topItems.length > 0) {
+        html += '<h3>Itens Mais Pedidos</h3><ul>';
+        topItems.forEach(item => {
+            html += `<li>${item.name} (${item.count})</li>`;
+        });
+        html += '</ul>';
+    } else {
+        html += '<p>Nenhum item registrado.</p>';
+    }
+    container.innerHTML = html;
 }
 
 function formatCartForWhatsApp(cartArray) {


### PR DESCRIPTION
## Summary
- add Analytics section in `index.html`
- compute basic metrics (total orders, average order value, top items)
- display analytics data in new section
- document analytics feature in README
- mark analytics task done in TODO

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ea946f8708325b2594b7b7ae3a291