### PR TITLE
Implement basic open/close status

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ googlePlaceId: "ChIJN1t_tDeuEmsRUsoyG83frY4"
 
 ### **Recursos Automáticos**
 
-- 🟢 **Status no Header** - "Aberto • Fecha às 23:00"
+- 🟢 **Status no Header** - "Aberto • Fecha às 23:00" (agora baseado em horário estático no `restaurantConfig`)
 - 🔴 **Modo Fechado** - "Fechado • Abre amanhã às 11:00"
 - ⚠️ **Banner Inteligente** - aparece quando fechado
 - 📝 **Pedidos Agendados** - aceita pedidos para processar depois

--- a/TODO.md
+++ b/TODO.md
@@ -96,9 +96,9 @@ This TODO list is derived from the project's `README.md` and aims to guide devel
   - **Sub-Task:** Develop a mechanism or page (potentially reusing `index.html` with specific URL params) to display a read-only summary of an order when accessed via a shareable URL.
   - **Sub-Task:** Add UI elements for copying/sharing the generated URL.
   - **Rationale:** Key unique feature mentioned in README, enhances professionalism and sharing.
-- [ ] **Task:** Basic Smart Scheduling System - Phase 1 (v1.x).
-  - **Sub-Task:** Add restaurant open/close times and timezone to `restaurantConfig` in `js/main.js`.
-  - **Sub-Task:** Implement logic in `js/main.js` to display a simple "Open" / "Closed" status based on current time and configured hours.
+- [~] **Task:** Basic Smart Scheduling System - Phase 1 (v1.x).
+  - **Sub-Task:** [x] Add restaurant open/close times and timezone to `restaurantConfig` in `js/main.js`.
+  - **Sub-Task:** [x] Implement logic in `js/main.js` to display a simple "Open" / "Closed" status based on current time and configured hours.
   - **Sub-Task:** (Future) Consider disabling "Add to Cart" or "Checkout" if closed, or allow pre-orders.
   - **Rationale:** First step towards "Sistema de Horários Inteligente" from README. Full Google Maps integration is a larger future phase.
 - [ ] **Task:** Implement Basic Contextual Item Suggestions (v1.x).

--- a/css/style.css
+++ b/css/style.css
@@ -44,6 +44,8 @@
   --past-order-border-color: #ccc;
   --past-order-heading-color: #555;
   --past-order-text-color: #444;
+    --status-open-color: #28a745;
+    --status-closed-color: #dc3545;
 }
 
 body.dark-mode {
@@ -92,6 +94,8 @@ body.dark-mode {
   --past-order-border-color: #555;
   --past-order-heading-color: #bbb;
   --past-order-text-color: #aaa;
+    --status-open-color: #28a745;
+    --status-closed-color: #dc3545;
 }
 
 body {
@@ -124,6 +128,19 @@ header h1 {
 header p {
   margin: 0;
   font-size: 1rem;
+}
+
+#open-status {
+    margin-top: 0.25rem;
+    font-weight: bold;
+}
+
+#open-status.open {
+    color: var(--status-open-color);
+}
+
+#open-status.closed {
+    color: var(--status-closed-color);
 }
 
 main {

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,8 +83,13 @@ Example in `js/main.js`:
 const restaurantConfig = {
   name: "Seu Restaurante Aqui", // Used in page header and WhatsApp messages
   phone: "5511999999999", // Used for WhatsApp "wa.me" links
+  timezone: "America/Sao_Paulo", // Timezone for scheduling
+  openTime: "11:00", // Opening hour
+  closeTime: "23:00", // Closing hour
 };
 ```
+
+These scheduling fields enable the header to display a basic "open" or "closed" status according to the configured hours.
 
 _(Future versions may move this to a dedicated configuration file or a user interface.)_
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <header>
         <h1>Tembiu</h1>
         <p>Seu cardápio digital open source!</p>
-        <!-- Status (Aberto/Fechado) will go here -->
+        <p id="open-status"></p>
         <button id="theme-toggle-button">Mudar Tema</button>
     </header>
 

--- a/js/main.js
+++ b/js/main.js
@@ -2,10 +2,13 @@ console.log("Tembiu main.js loaded.");
 
 // Client-side Restaurant Configuration (Placeholders)
 const restaurantConfig = {
-  name: "Tembiu Lanchonete Virtual", // Placeholder restaurant name
-  phone: "5511999999999", // Placeholder phone number (for wa.me link)
-  cidade: "São Paulo", // Placeholder city for PIX BR Code
-  // Future items: currency, deliveryFee, etc.
+    name: "Tembiu Lanchonete Virtual", // Placeholder restaurant name
+    phone: "5511999999999", // Placeholder phone number (for wa.me link)
+    cidade: "São Paulo", // Placeholder city for PIX BR Code
+    timezone: "America/Sao_Paulo", // Timezone for open/close status
+    openTime: "11:00", // Opening hour (24h format)
+    closeTime: "23:00", // Closing hour (24h format)
+    // Future items: currency, deliveryFee, etc.
   // Example for PIX Tel field (if different from WhatsApp or needs specific format)
   // pixTel: "11999999999"
 };
@@ -105,7 +108,43 @@ document.addEventListener("DOMContentLoaded", () => {
     document.body.classList.remove("dark-mode"); // Ensure it's not there if 'light' or null
     if (themeToggleButton) themeToggleButton.textContent = "Tema Escuro";
   }
+
+  initOpenStatus();
 });
+
+function initOpenStatus() {
+    const statusElem = document.getElementById("open-status");
+    if (!statusElem || !restaurantConfig.openTime || !restaurantConfig.closeTime) {
+        return;
+    }
+
+    function updateStatus() {
+        const localeTime = new Date().toLocaleTimeString("pt-BR", {
+            timeZone: restaurantConfig.timezone || "UTC",
+            hour12: false,
+        });
+        const [curH, curM] = localeTime.split(":").map(Number);
+        const [openH, openM] = restaurantConfig.openTime.split(":").map(Number);
+        const [closeH, closeM] = restaurantConfig.closeTime.split(":").map(Number);
+
+        const curMinutes = curH * 60 + curM;
+        const openMinutes = openH * 60 + openM;
+        const closeMinutes = closeH * 60 + closeM;
+
+        if (curMinutes >= openMinutes && curMinutes < closeMinutes) {
+            statusElem.textContent = `Aberto • Fecha às ${restaurantConfig.closeTime}`;
+            statusElem.classList.add("open");
+            statusElem.classList.remove("closed");
+        } else {
+            statusElem.textContent = `Fechado • Abre às ${restaurantConfig.openTime}`;
+            statusElem.classList.add("closed");
+            statusElem.classList.remove("open");
+        }
+    }
+
+    updateStatus();
+    setInterval(updateStatus, 60000);
+}
 
 async function loadMenu() {
   let menuItems = [];


### PR DESCRIPTION
## Summary
- display open/closed status in header
- add schedule configuration to `restaurantConfig`
- style open/closed status
- document schedule fields in docs and README
- mark scheduling task as started in `TODO.md`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869819f500483258739927646e96008